### PR TITLE
fix: theme bug, add client_theme

### DIFF
--- a/src/app/[locale]/agent/components/styles.ts
+++ b/src/app/[locale]/agent/components/styles.ts
@@ -1,6 +1,6 @@
 import { createStyles } from 'antd-style';
 
-export const useStyles = createStyles(({ token, isDarkMode }) => ({
+export const useStyles = createStyles(({ token }) => ({
   agentContainer: {
     'width': '100%',
     'position': 'relative',
@@ -31,7 +31,6 @@ export const useStyles = createStyles(({ token, isDarkMode }) => ({
     backgroundColor: token.colorBgLayout,
     padding: 16,
     borderRadius: '16px',
-    border: `${isDarkMode ? '1px solid' + token.colorBorder : null}`,
     cursor: 'pointer',
   },
   left: {
@@ -50,7 +49,7 @@ export const useStyles = createStyles(({ token, isDarkMode }) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     fontWeight: 700,
-    color: `${isDarkMode ? '#fff' : '#000'}`,
+    color: token.colorTextBase,
   },
   desc: {
     color: token.colorTextDescription,

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import type { Viewport } from 'next';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
 import { cookies } from 'next/headers';
+import Script from 'next/script';
 import React from 'react';
 
 import AppLayoutTemplate from '@/layout/AppLayoutTemplate';
@@ -30,13 +31,41 @@ export default function RootLayout({
   // dir === ltr | rtl
   return (
     <html dir={'ltr'} lang={locale}>
+      <head>
+        <Script id="theme-script" strategy="beforeInteractive">
+          {`(function() {
+  const setCookie = (name, value, days, path) => {
+    let expires = '';
+  
+    if (days) {
+      const date = new Date();
+      date.setTime(date.getTime() + (days || 1) * 24 * 60 * 60 * 1000);
+      expires = "; expires=" + date.toUTCString();
+    }
+    if (typeof window.document === 'object') {
+      // eslint-disable-next-line unicorn/no-document-cookie
+      window.document.cookie = name + "=" + value + expires + "; path=" + (path || '/');
+    }
+  };
+  if (window && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    setCookie('client_theme', 'dark');
+  } else {
+    setCookie('client_theme', 'light');
+  }
+})();`}
+        </Script>
+      </head>
       <body>
         <PWAHandlerLayout>
           <AxiosConfigLayout>
             <AuthLayout>
               <StyleRegistry>
                 <NextIntlClientProvider locale={locale} messages={messages}>
-                  <GlobalLayout locale={locale} theme={cookies().get('theme')?.value || 'auto'}>
+                  <GlobalLayout
+                    client_theme={cookies().get('client_theme')?.value}
+                    locale={locale}
+                    theme={cookies().get('theme')?.value || 'auto'}
+                  >
                     <AppLayoutTemplate>{children}</AppLayoutTemplate>
                   </GlobalLayout>
                 </NextIntlClientProvider>

--- a/src/layout/AppLayout/SideBar/Chats/Item.tsx
+++ b/src/layout/AppLayout/SideBar/Chats/Item.tsx
@@ -103,6 +103,7 @@ export const useStyles = createStyles(({ token }) => {
 interface Props {
   data: {
     id: string;
+    icon: string; // img base64 = =
     title: string;
     desc: string;
     app_namespace: string;
@@ -187,7 +188,7 @@ const ChatItem: any = (props: Props) => {
         }}
       >
         <div className={styles.icon}>
-          <Image alt="default_chat" height={42} src="/default_chat.png" width={42} />
+          <Image alt="default_chat" height={42} src={data.icon || '/default_chat.png'} width={42} />
         </div>
         <div className={styles.content}>
           <Typography.Paragraph className={styles.title} ellipsis>

--- a/src/layout/AppLayout/SideBar/UserInfoBottom.tsx
+++ b/src/layout/AppLayout/SideBar/UserInfoBottom.tsx
@@ -159,7 +159,7 @@ export default function UserInfoBottom() {
               onClick: ({ key }) => {
                 if (theme === key) return;
                 dispatch({
-                  type: 'TRIGGER_SHEME',
+                  type: 'TRIGGER_THEME',
                   theme: key,
                 });
               },
@@ -176,7 +176,7 @@ export default function UserInfoBottom() {
               onClick={() => {
                 if (theme === 'auto') return;
                 dispatch({
-                  type: 'TRIGGER_SHEME',
+                  type: 'TRIGGER_THEME',
                   theme: theme === 'light' ? 'dark' : 'light',
                 });
               }}

--- a/src/layout/GlobalLayout/index.tsx
+++ b/src/layout/GlobalLayout/index.tsx
@@ -12,10 +12,11 @@ import ThemeLayout from './ThemeLayout';
 
 interface GlobalLayoutProps extends PropsWithChildren {
   theme: ThemeMode | undefined; // theme from cookie;
+  client_theme: 'dark' | 'light' | undefined;
   locale: string;
 }
 
-const GlobalLayout = React.memo<GlobalLayoutProps>(({ children, theme, locale }) => {
+const GlobalLayout = React.memo<GlobalLayoutProps>(({ children, theme, locale, client_theme }) => {
   const store = useStore({
     theme,
   });
@@ -23,6 +24,7 @@ const GlobalLayout = React.memo<GlobalLayoutProps>(({ children, theme, locale })
     <Provider store={store}>
       <ThemeLayout
         antdLocale={locale?.startsWith('zh') ? zhCN : enUS}
+        client_theme={client_theme}
         locale={locale}
         theme={theme}
       >

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,7 +10,7 @@ let store: any;
 
 const reducer = (state = {}, action: any) => {
   switch (action.type) {
-    case 'TRIGGER_SHEME': {
+    case 'TRIGGER_THEME': {
       setCookie('theme', action.theme); // todo remove, use user profile by bff ?
       return {
         ...state,

--- a/src/theme/themeConfig.ts
+++ b/src/theme/themeConfig.ts
@@ -30,7 +30,7 @@ const light_theme_props: ThemeProviderProps = Object.freeze({
   },
 });
 
-const datk_theme_props: ThemeProviderProps = Object.freeze({
+const dark_theme_props: ThemeProviderProps = Object.freeze({
   theme: {
     token: {
       colorBgBase: '#000',
@@ -46,5 +46,5 @@ const datk_theme_props: ThemeProviderProps = Object.freeze({
 });
 
 export const light = light_theme_props;
-export const dark = datk_theme_props;
+export const dark = dark_theme_props;
 export const default_theme = default_theme_props;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

1. ssr 的环境中，无法直接判断客户端是否处于暗色模式（prefers-color-scheme: dark）, 无法访问 window 或 document

并且目前使用的是 css-in-js 方案处理样式, 无法使用媒体查询处理
故采取折中方案: 存储 client_theme ( dark | light ), 初次访问页面时, 如果当前为跟随系统, 且系统主题(dark|light)与当前项目(light|dark)不一致时, 会闪烁一次, **后续再次刷新不会出现此问题**

2. use chat item icon
![image](https://github.com/kubeagi/agent-portal/assets/11804448/3a6423c1-adcd-4ae1-8e2f-ffbbd7307f8d)

#### 📝 补充信息 | Additional Information

fixed: #59, fixed: https://github.com/kubeagi/ops-console/issues/282
