### PR TITLE
refactor: replace custom server with default server in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "next build",
     "build:analyze": "cross-env ANALYZE=true next build",
-    "dev": "node server.mjs",
+    "dev": "next dev",
     "lint": "npm run lint:es && npm run lint:style",
     "lint-fix": "npm run lint-fix:es && npm run lint-fix:style",
     "lint-fix:es": "eslint --ext .jsx,.js,.tsx,.ts src --fix",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,14 @@ import { NextRequest } from 'next/server';
 import { locales } from './i18n';
 import { LOCALE } from './utils/constants';
 
+const isProd = process.env.NODE_ENV === 'production';
+const APIPrefix = process.env.API_PREFIX;
+
 export default async function middleware(request: NextRequest) {
+  if (!isProd && request.nextUrl.pathname.startsWith(APIPrefix)) {
+    return;
+  }
+
   const acceptLanguage =
     request.headers.get('accept-language')?.split(';')?.[0]?.split(',')?.[0]?.split('-')?.[0] || '';
   const defaultLocale: string =


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs
- [x] refactor 

#### 🔀 变更说明 | Description of Change

refactor: replace custom server with default server in development

#### 📝 补充信息 | Additional Information

1. just add one proxy context '/kubeagi-apis'
2. The next step is to replace with the default server in PROD enviroment, which supports HTTPS. By doing so, the project can reduce third-party dependencies and enjoy the optimization of default servers
3.  In the longer term, it is possible to package only the client code with Next.js, SSR may not appear necessary, and the project may not require SEO. By doing so,  it is possible to reduce the cost for front-end engineers to maintain the server (concurrency and transactions, as well as possible interactions with cache and message queues, even under isomorphism), as well as the potential single point of failure that projects may encounter in the server environment